### PR TITLE
2 Minor post-native-linux fixes

### DIFF
--- a/E33Randomizer/E33Randomizer.csproj
+++ b/E33Randomizer/E33Randomizer.csproj
@@ -81,7 +81,7 @@
         </ItemGroup>
     </Target>
     
-    <Target Name="EnsureRetocAndUesave" BeforeTargets="Build">
-        <Exec Condition="!Exists('..\external\retoc') Or !Exists('..\external\retoc.exe') Or !Exists('..\external\uesave') Or !Exists('..\external\uesave.exe')" WorkingDirectory="$(SolutionDir)ScriptsAndHelpers" Command="dotnet FetchExternalApplications.cs" />
+    <Target Name="EnsureRetocAndUesave" BeforeTargets="BeforeBuild">
+        <Exec Condition="!Exists('$(SolutionDir)\external\retoc') Or !Exists('$(SolutionDir)\external\retoc.exe') Or !Exists('$(SolutionDir)\external\uesave') Or !Exists('$(SolutionDir)\external\uesave.exe')" WorkingDirectory="$(SolutionDir)ScriptsAndHelpers" Command="dotnet FetchExternalApplications.cs" />
     </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Enemy rando overrides `DT_jRPG_Encounters`, `DT_jRPG_Encounters_CleaTower`, `DT_
 ### Developer Guidlines
 
 - All user displayed strings (other than the presets and item/skill/character/location data) are found in the `Resources.resx` file.  While this application is not currently localized, due to the international love of the game, this keeps that door open for the future.  Please do not embed user displayed strings directly into the code or axaml files.
-- All the Json handling is done via `System.Text.Json` within the main `E33Randomizer` project, do not use Newtonsoft.Json.  If UAssetAPI ever moves to being AotCompatible, It'd e nice to do that here too and NewtonsoftJson is never going to be AoT Compatible.
+- All the Json handling is done via `System.Text.Json` within the main `E33Randomizer` project, do not use `Newtonsoft.Json`.  If UAssetAPI ever moves to being AotCompatible, It'd be nice to do that here too and `Newtonsoft.Json` is never going to be AoT Compatible.
 - When possible avoid locally styling single items and rely on setting the styles in [Styles.axaml](E33Randomizer/Styles.axaml) or [UIControls](E33Randomizer/UIControls).  This ensures that the app remains visually consistent.
 - In general, prefer to use ViewModels for binding rather than binding interactions in the code behinds for the `Windows` or `UserControls`
 - If the version of uesave or retoc needs to be updated, update the `external-assembly-version.json`.  You need to set the version and also grab the checksums from the release.


### PR DESCRIPTION
* The step during build to copy the repak/retoc/uesave files needed to happen in the BeforeBuild target, otherwise it could fail.  And the path could be wrong depending on where you started the dotnet build from.

* The README had a typo that we knew about in the original PR, this fixes that. 

